### PR TITLE
Remove 'get inspired' section from homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -60,23 +60,22 @@ body-class: "home"
 <section class="p-strip is-deep">
   <div class="row">
     <div class="col-3">
-      <h3><a href="audiences">Our audiences &rsaquo;</a></h3>
-      <p>Find out how to tailor your designs depending on which audience you are catering for, with the help of three handy sliders.</p>
+      <h3><a href="brand">Brand&nbsp;&rsaquo;</a></h3>
+      <p>Learn about the elements that constitute the Ubuntu brand and how to use them, such as the Ubuntu and Canonical logos, pictograms and product photography.</p>
     </div>
     <div class="col-3">
-      <h3><a href="brand">Brand assets &rsaquo;</a></h3>
-      <p>Learn about the elements that constitute the Ubuntu brand and how to use them, such as the Ubuntu and Canonical logos, pictograms, photography, etc.</p>
+      <h3><a href="web-style-guide">Web&nbsp;&rsaquo;</a></h3>
+      <p>Find out about the Vanilla Framework, created to ease design and development of Ubuntu and Canonical sites, and free to use on your own projects too.</p>
     </div>
     <div class="col-3">
-      <h3><a href="web-style-guide">Web guidelines &rsaquo;</a></h3>
-      <p>See how to use the Ubuntu brand on the web, from the logo to the Ubuntu font family, colours, forms, navigation and more design patterns and components.</p>
+      <h3><a href="font">Font&nbsp;&rsaquo;</a></h3>
+      <p>Learn more about the Ubuntu font family, the available fonts, weights and languages, and how to get it for free.</p>
     </div>
     <div class="col-3">
-      <h3>Quick links</h3>
+      <h3>More</h3>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a href="/brand/ubuntu-logo">Ubuntu logo &rsaquo;</a></li>
-        <li class="p-list__item"><a href="/brand/canonical-logo">Canonical logo &rsaquo;</a></li>
-        <li class="p-list__item"><a href="/brand/colour-palette">Colour palette &rsaquo;</a></li>
+        <li class="p-list__item"><a href="/brand/examples">Examples&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/downloads">Downloads&nbsp;&rsaquo;</a></li>
       </ul>
     </div>
   </div>

--- a/index.md
+++ b/index.md
@@ -5,9 +5,8 @@ body-id: "home"
 body-class: "home"
 ---
 
-<div class="p-strip">
+<section class="p-strip is-deep is-bordered">
   <div class="row">
-    <div class="col-12">
       <div class="col-6">
         <h1><span>You make Ubuntu <br/>You use Ubuntu <br/>You talk Ubuntu</span> <br/>Ubuntu is yours</h1>
         <p>The Ubuntu Brand Guidelines exist so we can all communicate Ubuntu with the same precision we use to make it.</p>
@@ -16,23 +15,22 @@ body-class: "home"
         <img src="{{ site.assets_path }}78b7c44a-hero-dots.png" width="460" height="380" alt="Ubuntu colours arranged as a dot pattern" />
       </div>
     </div>
-  </div>
-</div>
+</section>
 
-<div class="p-strip--image is-light" style="background-image:url('{{ site.assets_path }}f8a323a7-image-background-paper.png');">
+<section class="p-strip--image is-light is-deep" style="background-image:url('{{ site.assets_path }}f8a323a7-image-background-paper.png');">
   <div class="row u-vertically-center">
     <div class="col-3">
       <img src="{{ site.assets_path }}54cd98ab-knowledge_orange_hex2.png" alt="knowledge pictogram" title="knowledge_orange_hex" width="140" height="113"/>
     </div>
-    <div class="col-9">
+    <div class="col-9 suffix-1">
       <h2>Why do we need guidelines?</h2>
       <p>Our values should be evident wherever Ubuntu is encountered, whether online or via traditional marketing material. If we follow these guidelines consistently, the brand will grow strong enough to attract people, encouraging them to look even more positively on the product itself.</p>
       <p>These guidelines provide everything you need to create professional communication <br/>materials that will build the Ubuntu brand. To help ensure the continued success of Ubuntu, please use them.</p>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip--accent">
+<section class="p-strip--accent  is-deep">
   <div class="row">
     <div class="col-8">
       <h2>Our values</h2>
@@ -57,9 +55,9 @@ body-class: "home"
       <p>Working together is at the heart of Ubuntu. It is the essence of &rsquo;humanity towards others&lsquo;.</p>
     </div>
   </div>
-</div>
+</section>
 
-<div class="p-strip">
+<section class="p-strip is-deep">
   <div class="row">
     <div class="col-3">
       <h3><a href="audiences">Our audiences &rsaquo;</a></h3>
@@ -78,105 +76,8 @@ body-class: "home"
       <ul class="p-list--divided">
         <li class="p-list__item"><a href="/brand/ubuntu-logo">Ubuntu logo &rsaquo;</a></li>
         <li class="p-list__item"><a href="/brand/canonical-logo">Canonical logo &rsaquo;</a></li>
-        <li class="last"><a href="/brand/colour-palette">Colour palette &rsaquo;</a></li>
+        <li class="p-list__item"><a href="/brand/colour-palette">Colour palette &rsaquo;</a></li>
       </ul>
     </div>
   </div>
-</div>
-
-<div class="p-strip">
-  <div class="row no-border">
-    <div class="box-padded sliding">
-      <div class="slider-controls">
-        <div class="next"></div>
-        <div class="prev disabled"></div>
-      </div>
-      <h3>Get inspired</h3>
-
-      <div>
-        <ul class="slider clearfix">
-          <li class="p-list__item">
-            <a class="pretty-photo" href="{{ site.assets_path }}152a19e1-ubuntu-web-ubuntu-for-you.png">
-              <img src="{{ site.assets_path }}b67fb5f7-ubuntu-web-ubuntu-for-you-140x140.png" width="140" height="140" title="Ubuntu for you page on Ubuntu.com" alt="Ubuntu for you page on Ubuntu.com" />
-            </a>
-          </li>
-          <li class="p-list__item">
-            <a class="pretty-photo" href="{{ site.assets_path }}2571b5ee-landscape-homepage2.png">
-              <img src="{{ site.assets_path }}f23d1298-landscape-homepage2-140x140.png" width="140" height="140" title="Landscape website homepage" alt="Landscape website homepage" />
-            </a>
-          </li>
-          <li class="p-list__item">
-            <a class="pretty-photo" href="{{ site.assets_path }}4806a317-ubuntu-web-form-contact-canonical.png">
-              <img src="{{ site.assets_path }}4da8641d-ubuntu-web-form-contact-canonical-140x140.png" width="140" height="140" title="Contact Canonical form on Ubuntu.com" alt="Contact Canonical form on Ubuntu.com" />
-            </a>
-          </li>
-          <li class="p-list__item">
-            <a class="pretty-photo" href="{{ site.assets_path }}cdbac36f-ubuntu-web-homepage.png">
-              <img src="{{ site.assets_path }}9ea48b2b-ubuntu-web-homepage-140x140.png" width="140" height="140" title="Ubuntu.com homepage" alt="Ubuntu.com homepage" />
-            </a>
-          </li>
-          <li class="row-end">
-            <a class="pretty-photo" href="{{ site.assets_path }}bdc631cc-canonical-white-paper.png">
-              <img src="{{ site.assets_path }}a43cdfad-canonical-white-paper-140x140.png" width="140" height="140" title="Canonical white paper" alt="Canonical white paper" />
-            </a>
-          </li>
-          <li class="p-list__item">
-            <a class="pretty-photo" href="{{ site.assets_path }}7db1f2a9-ubuntu-we-are-cloud-ad.png">
-              <img src="{{ site.assets_path }}26acb47e-ubuntu-we-are-cloud-ad-140x140.png" width="140" height="140" title="We are cloud campaign poster" alt="We are cloud campaign poster" />
-            </a>
-          </li>
-          <li class="p-list__item">
-            <a class="pretty-photo" href="{{ site.assets_path }}298bce76-ubuntu-server-edition-cd-packaging-1010.png">
-              <img src="{{ site.assets_path }}991870d8-ubuntu-server-edition-cd-packaging-1010-140x140.png" width="140" height="140" title="Ubuntu 10.10 Server Edition CD packaging" alt="Ubuntu 10.10 Server Edition CD packaging" />
-            </a>
-          </li>
-          <li class="p-list__item">
-            <a class="pretty-photo" href="{{ site.assets_path }}f225b375-ubuntu-server-brochure-diagram.png">
-              <img src="{{ site.assets_path }}2ebf6822-ubuntu-server-brochure-diagram-140x140.png" width="140" height="140" title="Ubuntu Server brochure diagrams" alt="Ubuntu Server brochure diagrams" />
-            </a>
-          </li>
-          <li class="p-list__item">
-            <a class="pretty-photo" href="{{ site.assets_path }}6ea970f9-ubuntu-cd-packaging-1010.png">
-              <img src="{{ site.assets_path }}48a841df-ubuntu-cd-packaging-1010-140x140.png" width="140" height="140" title="Ubuntu 10.10 CD packaging" alt="Ubuntu 10.10 CD packaging" />
-            </a>
-          </li>
-          <li class="row-end">
-            <a class="pretty-photo" href="{{ site.assets_path }}df5aeb05-ubuntu-advantage-brochures.png">
-              <img src="{{ site.assets_path }}c32194fd-ubuntu-advantage-brochures-140x140.png" width="140" height="140" title="Ubuntu Advantage brochures" alt="Ubuntu Advantage brochures" />
-            </a>
-          </li>
-          <li class="p-list__item">
-            <a class="pretty-photo" href="{{ site.assets_path }}180a7441-mug-notebook.png">
-              <img src="{{ site.assets_path }}1609bb9f-mug-notebook-140x140.png" width="140" height="140" title="Ubuntu mug and notebook" alt="Ubuntu mug and notebook" />
-            </a>
-          </li>
-          <li class="p-list__item">
-            <a class="pretty-photo" href="{{ site.assets_path }}93514a11-ubuntu-one-homepage.png">
-              <img src="{{ site.assets_path }}ed7d2d69-ubuntu-one-homepage-140x140.png" width="140" height="140" title="Ubuntu One homepage" alt="Ubuntu One homepage" />
-            </a>
-          </li>
-          <li class="p-list__item">
-            <a class="pretty-photo" href="{{ site.assets_path }}8c24b2c4-landscape-dashboard-logged-in.png">
-              <img src="{{ site.assets_path }}b1dc7567-landscape-dashboard-logged-in-140x140.png" width="140" height="140" title="Landscape dashboard" alt="Landscape dashboard" />
-            </a>
-          </li>
-          <li class="p-list__item">
-            <a class="pretty-photo" href="{{ site.assets_path }}ce7c79b5-font-ubuntu-com-homepage.png">
-              <img src="{{ site.assets_path }}c8c93892-font-ubuntu-com-homepage-140x140.png" width="140" height="140" title="Ubuntu Font Family website" alt="Ubuntu Font Family website" />
-            </a>
-          </li>
-          <li class="row-end">
-            <a class="pretty-photo" href="{{ site.assets_path }}296936bc-omgubuntu-homepage.png">
-              <img src="{{ site.assets_path }}5efc7079-omgubuntu-homepage-140x140.png" width="140" height="140" title="OMG! Ubuntu! homepage" alt="OMG! Ubuntu! homepage" />
-            </a>
-          </li>
-        </ul>
-        <ul class="slider-jump">
-          <li class="dot1 active"></li>
-          <li class="dot2"></li>
-          <li class="dot3"></li>
-        </ul>
-      </div>
-    </div>
-  </div>
-</div>
+</section>


### PR DESCRIPTION
## Done

* Remove 'get inspired' section from homepage
* some html tidy-ups

## QA

1. ./run serve -w
2. look at the [homepage](http://0.0.0.0:8011/) or [demo](http://design.ubuntu.com-vbt-updates.demo.haus/)

## Issue / Card

Fixes #7 and [launchpad bug 1538131]https://bugs.launchpad.net/ubuntu-brand-guidelines/+bug/1538131

