### PR TITLE
Remove vendor/bundle to avoid building Jekyll tests

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,3 +41,4 @@ exclude:
   - run
   - yarn.lock
   - node_modules
+  - vendor/bundle


### PR DESCRIPTION
## Done

Prevent Jekyll building test files in some cases and throwing this error:
```
Configuration file: ...
            Source: ...
       Destination: ...
 Incremental build: enabled
      Generating...
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.0.0/gems/jekyll-3.4.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.

```

## QA

./run should still work correctly (Or the demo below)

