### PR TITLE
Update the download page sorting options

### DIFF
--- a/_includes/side-nav-downloads.html
+++ b/_includes/side-nav-downloads.html
@@ -1,120 +1,91 @@
-<span class="filter-toggle">Filter by</span>
-<div class="filter">
-  <h2>Filters</h2>
-  <form id="form-filter-search" action="downloads" method="get" class="hidden">
-    <h3>Filter by:</h3>
-    <fieldset >
-      <input type="text" name="search" value="" />
-      <input type="submit" name="submit" value="" />
-    </fieldset>
-  </form>
-  <div id="accordion">
-    <h3><a href="downloads#">Anchor points</a></h3>
-    <div>
-      <h4>Voice</h4>
-      <input id="voice-community" type="checkbox" />
-      <label for="voice-community">Community</label><br/>
-      <input id="voice-canonical" type="checkbox" />
-      <label for="voice-canonical">Canonical</label><br/>
-
-      <h4>Audience</h4>
-      <input id="audience-consumer" type="checkbox" />
-      <label for="audience-consumer">Consumer</label><br/>
-      <input id="audience-enterprise" type="checkbox" />
-      <label for="audience-enterprise">Enterprise</label><br/>
-
-      <h4>Developer</h4>
-      <input id="developer-user" type="checkbox" />
-      <label for="developer-user">User</label><br/>
-      <input id="developer-developer" type="checkbox" />
-      <label for="developer-developer">Developer</label><br/>
-    </div>
-
-    <h3><a href="downloads#" class="slideless">Element</a></h3>
-    <div>
-      <fieldset>
-        <input id="element-logo" type="checkbox" />
-        <label for="element-logo">Logo</label><br/>
-        <input id="element-font" type="checkbox" />
-        <label for="element-font">Font</label><br/>
-        <input id="element-colour" type="checkbox" />
-        <label for="element-colour">Colour</label><br/>
-        <input id="element-pictogram" type="checkbox" />
-        <label for="element-pictogram">Pictogram</label><br/>
-        <input id="element-dots" type="checkbox" />
-        <label for="element-dots">Dots</label><br/>
-        <input id="element-extension" type="checkbox" />
-        <label for="element-extension">Brand extension</label><br/>
-        <input id="element-photography" type="checkbox" />
-        <label for="element-photography">Photography</label><br/>
-        <input id="element-illustration" type="checkbox" />
-        <label for="element-illustration">Illustration</label><br/>
-        <input id="element-presentation" type="checkbox" />
-        <label for="element-presentation">Presentation</label><br/>
-        <input id="element-voice" type="checkbox" />
-        <label for="element-voice">Tone of voice</label><br/>
-        <input id="element-bubble" type="checkbox" />
-        <label for="element-bubble">Quote bubble</label><br/>
-        <input id="element-form" type="checkbox" />
-        <label for="element-form">Web form</label><br/>
-        <input id="element-shadow" type="checkbox" />
-        <label for="element-shadow">Web drop shadows</label><br/>
-        <input id="element-corner" type="checkbox" />
-        <label for="element-corner">Web rounded corners</label><br/>
+<div class="col-3">
+  <span class="filter-toggle">Filter by</span>
+  <div class="filter">
+    <h2>Filters</h2>
+    <form id="form-filter-search" action="downloads" method="get" class="hidden">
+      <h3>Filter by:</h3>
+      <fieldset >
+        <input type="text" name="search" value="" />
+        <input type="submit" name="submit" value="" />
       </fieldset>
-    </div>
+    </form>
+    <div id="accordion">
+      <h3><a href="downloads#" class="slideless">Element</a></h3>
+      <div>
+        <fieldset>
+          <input id="element-charts" type="checkbox" />
+          <label for="element-charts">Charts and diagrams</label><br/>
+          <input id="element-color" type="checkbox" />
+          <label for="element-color">Colour</label><br/>
+          <input id="element-grid" type="checkbox" />
+          <label for="element-grid">Grid</label><br/>
+          <input id="element-logo" type="checkbox" />
+          <label for="element-logo">Logo</label><br/>
+          <input id="element-pattern" type="checkbox" />
+          <label for="element-pattern">Pattern</label><br/>
+          <input id="element-pictorgram" type="checkbox" />
+          <label for="element-pictorgram">Pictogram</label><br/>
+          <input id="element-presentation" type="checkbox" />
+          <label for="element-presentation">Presentation</label><br/>
+          <input id="element-product-photography" type="checkbox" />
+          <label for="element-product-photography">Product photography</label><br/>
+          <input id="element-screenshot" type="checkbox" />
+          <label for="element-screenshot">Screenshot</label><br/>
+          <input id="element-tone" type="checkbox" />
+          <label for="element-tone">Tone of voice</label><br/>
+          <input id="element-typography" type="checkbox" />
+          <label for="element-typography">Typography</label><br/>
+        </fieldset>
+      </div>
 
-    <h3><a href="downloads#" class="slideless">Colour</a></h3>
-    <div>
-      <fieldset>
-        <input id="colour-orange" type="checkbox" />
-        <label for="colour-orange">Orange</label><br/>
-        <input id="colour-aubergine" type="checkbox" />
-        <label for="colour-aubergine">Aubergine</label><br/>
-        <input id="colour-black" type="checkbox" />
-        <label for="colour-black">Black</label><br/>
-        <input id="colour-white" type="checkbox" />
-        <label for="colour-white">White</label>
-      </fieldset>
-    </div>
+      <h3><a href="downloads#" class="slideless">Brand</a></h3>
+      <div>
+        <fieldset>
+          <input id="brand-ubuntu" type="checkbox" />
+          <label for="brand-ubuntu">Ubuntu</label><br/>
+          <input id="brand-canonical" type="checkbox" />
+          <label for="brand-canonical">Canonical</label>
+        </fieldset>
+      </div>
 
-    <h3><a href="downloads#" class="slideless">Brand</a></h3>
-    <div>
-      <fieldset>
-        <input id="brand-ubuntu" type="checkbox" />
-        <label for="brand-ubuntu">Ubuntu</label><br/>
-        <input id="brand-canonical" type="checkbox" />
-        <label for="brand-canonical">Canonical</label>
-      </fieldset>
-    </div>
+      <h3><a href="downloads#" class="slideless">Channel</a></h3>
+      <div>
+        <fieldset>
+          <input id="channel-general" type="checkbox" />
+          <label for="channel-general">General</label><br/>
+          <input id="channel-platform" type="checkbox" />
+          <label for="channel-platform">Platform</label><br/>
+          <input id="channel-print" type="checkbox" />
+          <label for="channel-print">Print</label><br/>
+          <input id="channel-web" type="checkbox" />
+          <label for="channel-web">Web</label>
+        </fieldset>
+      </div>
 
-    <h3><a href="downloads#" class="slideless">Channel</a></h3>
-    <div>
-      <fieldset>
-        <input id="channel-general" type="checkbox" />
-        <label for="channel-general">General</label><br/>
-        <input id="channel-desktop" type="checkbox" />
-        <label for="channel-desktop">Desktop</label><br/>
-        <input id="channel-print" type="checkbox" />
-        <label for="channel-print">Print</label><br/>
-        <input id="channel-web" type="checkbox" />
-        <label for="channel-web">Web</label>
-      </fieldset>
-    </div>
+      <h3><a href="downloads#" class="slideless">Product</a></h3>
+      <div>
+        <fieldset>
+          <input id="product-ubuntu-desktop" type="checkbox" />
+          <label for="product-ubuntu-desktop">Ubuntu Desktop</label><br/>
+          <input id="product-ubuntu-cloud" type="checkbox" />
+          <label for="product-ubuntu-cloud">Ubuntu Cloud</label><br/>
+          <input id="product-ubuntu-server" type="checkbox" />
+          <label for="product-ubuntu-server">Ubuntu Server</label><br/>
+          <input id="product-ubuntu-advantage" type="checkbox" />
+          <label for="product-ubuntu-advantage">Ubuntu Advantage</label><br/>
+          <input id="product-juju" type="checkbox" />
+          <label for="product-juju">Juju</label><br/>
+          <input id="product-maas" type="checkbox" />
+          <label for="product-maas">MAAS</label><br/>
+          <input id="product-landscape" type="checkbox" />
+          <label for="product-landscape">Landscape</label><br/>
+          <input id="product-iot" type="checkbox" />
+          <label for="product-iot">IoT</label><br/>
+          <input id="product-vanilla" type="checkbox" />
+          <label for="product-vanilla">Vanilla</label><br/>
+        </fieldset>
+      </div>
 
-    <h3><a href="downloads#" class="slideless">Product</a></h3>
-    <div>
-      <fieldset>
-        <input id="product-ubuntu" type="checkbox" />
-        <label for="product-ubuntu">Ubuntu</label><br/>
-        <input id="product-one" type="checkbox" />
-        <label for="product-one">Ubuntu One</label><br/>
-        <input id="product-cloud" type="checkbox" />
-        <label for="product-cloud">Cloud</label><br/>
-        <input id="product-server" type="checkbox" />
-        <label for="product-server">Server</label>
-      </fieldset>
     </div>
-
-  </div><!-- /#accordion -->
-</div><!-- /.filter -->   
+  </div>
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -23,7 +23,7 @@
         {% include side-nav-downloads.html %}
       {% endif %}
 
-      <div class="{% if page.body-id=="downloads" %}col-10{% elsif page.body-id=="brand-assets" %}col-8{% else %}col-12{% endif %}">
+      <div class="{% if page.body-id=="downloads" %}col-9{% else %}col-12{% endif %}">
         {{ content }}
       </div>
     </div>


### PR DESCRIPTION
## Done

Updated the list of filters at on the left-hand side of the dowloads page.

*Note*: This is just an update of the page content and the correct grid placement. The full design update will be done as part of the vanilla upgrade (to utilise the new patterns) and the tagging of the design assets will be done when we update the assets closer to launch.

## QA

- ./run
- View the [download page](http://localhost:8011/downloads/) and see that, although not well designed, the correct [download filters](https://docs.google.com/document/d/1QIUUzAxF1Musm7LfKNO_Cvx3vpuqJM-QZozDKznivhs/edit) are present

## Issue / Card

Fixes #44 
