### PR TITLE
Add Dockerfile

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,18 @@
+---
+layout: home
+title: "404: Page not found"
+body-id: "404"
+body-class: "404"
+---
+
+<section class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <img src="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg?w=365" alt="" width="365">
+    </div>
+    <div class="col-6">
+      <h1>404: Page not found</h1>
+      <p>Sorry, we couldn’t find that page.</p>
+    </div>
+  </div>
+</section>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get install --yes nginx
+
+# Set git commit ID
+ARG COMMIT_ID=""
+
+# Copy over files
+WORKDIR /srv
+ADD _site .
+ADD nginx.conf /etc/nginx/sites-enabled/default
+RUN sed -i "s/~COMMIT_ID~/${COMMIT_ID}/" /etc/nginx/sites-enabled/default
+
+STOPSIGNAL SIGTERM
+
+CMD ["nginx", "-g", "daemon off;"]
+

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,44 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    root /srv;
+
+    index index.html;
+
+    # Log to stdout
+    access_log /dev/stdout;
+    error_log /dev/stderr info;
+
+    # Show 404 page
+    error_page 404 /404.html;
+
+    # Show commit-id
+    add_header X-Commit-ID ~COMMIT_ID~ always;
+    add_header X-Hostname $hostname always;
+
+    server_name _;
+
+    # Remove index or index.html from URIs
+    if ($request_uri ~ ^.*/index(.html)?$) {
+        rewrite ^(.*/)index(.html)? $1 permanent;
+    }
+
+    # Remove slashes form URIs if it's not a directory
+    if (!-d $request_filename) {
+        rewrite ^/(.*)/$ /$1 permanent;
+    }
+
+    # Add slashes from URIs if it's a directory
+    if (-d $request_filename) {
+        rewrite ^/(.*[^/])$ /$1/ permanent;
+    }
+
+    # For finding files from URIs
+    # First try the URI directly, then try adding .html, then try treating it as a directory
+    # Finally fall back to 404
+    location ~ ^/.+$ {
+        try_files $uri $uri.html $uri/ =404;
+    }
+}
+


### PR DESCRIPTION
- Add Dockerfile for building web app image
- Driveby: Add a 404 page

Fixes #93 

QA
--

Build and run the docker image:

``` bash
docker build --tag design-site --build-arg COMMIT_ID=`git rev-parse HEAD` .
docker run -p 80:80 design-site
```

Go to <http://127.0.0.1> and see the design site in all its glory. Go to <http://127.0.0.1/nonsense> and see a 404 page.