### PR TITLE
Make COMMIT_ID mandatory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:xenial
 RUN apt-get update && apt-get install --yes nginx
 
 # Set git commit ID
-ARG COMMIT_ID=""
+ARG COMMIT_ID
+RUN test -n "${COMMIT_ID}"
 
 # Copy over files
 WORKDIR /srv


### PR DESCRIPTION
Provide the ID of the commit at which point the code was built, as a HTTP header in the response from the docker container.

For production - so we can easily see which version of the code is running on a unit.

QA
--

``` bash
$ docker build .  # Check it complains without COMMIT_ID
The command '/bin/sh -c test -n "${COMMIT_ID}"' returned a non-zero code: 1
$ docker build --tag design --build-arg COMMIT_ID=`git rev-parse HEAD` .  # Build with COMMIT_ID
$ docker run --rm --name design-throwaway --daemonize --publish 8097:80 design
$ curl -I localhost:8097 | grep 'X-'
X-commit-ID: 018f47199c3709e9d0bceb33bef30546ee76e820
X-Hostname: 096dbd5ae462
$ docker kill design-throwaway
```