### PR TITLE
Bump global nav version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "autoprefixer": "^6.3.1",
     "cssnano": "^3.10.0",
-    "global-nav": "^0.1.3",
+    "global-nav": "^0.2.2",
     "node-sass": "^4.5.3",
     "postcss-cli": "^4.1.0",
     "sass-lint": "^1.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,9 +1043,9 @@ glob@~3.1.21:
     inherits "1"
     minimatch "~0.2.11"
 
-global-nav@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/global-nav/-/global-nav-0.1.3.tgz#98b997bbd701ab00bfc53e37c17469d80c04b519"
+global-nav@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/global-nav/-/global-nav-0.2.2.tgz#fc72aa66739e1a161fbaed4c71bb56d077371314"
 
 globals@^9.2.0:
   version "9.17.0"


### PR DESCRIPTION
## Done

Bump global nav version

## QA

- Clone this repo
- `./run serve`
- Go to <http://0.0.0.0:8011>
- Make sure 'ubuntu' link in main nav goes to ubuntu.com

## Issue / Card
[Fixes #235](https://app.zenhub.com/workspace/o/canonical-websites/insights.ubuntu.com/issues/235)
