### PR TITLE
Fix link to colour palette

### DIFF
--- a/brand/illustration/index.md
+++ b/brand/illustration/index.md
@@ -23,7 +23,7 @@ body-class: "guidelines"
     <p>When creating diagrams, use either the widely or tightly spaced dots as a background grid. The tightly spaced dots are used to define the top and bottom of the diagram along with creating a title bar and section breaks within the diagram.</p>
     <p><img src="{{ site.assets_path }}83e61f97-dots-dev-diagram.gif" alt="Diagram using a developer dots background" title="dots-dev-diagram" width="540" height="234" srcset="{{ site.assets_path }}83e61f97-dots-dev-diagram.gif 540w, {{ site.assets_path }}d4c19c5a-dots-dev-diagram-300x130.gif 300w" sizes="(max-width: 540px) 100vw, 540px" /></p>
     <p><img src="{{ site.assets_path }}9d934818-dots-enterprise-diagram.gif" alt="" title="dots-enterprise-diagram" width="540" height="360" srcset="{{ site.assets_path }}9d934818-dots-enterprise-diagram.gif 540w, {{ site.assets_path }}f114927e-dots-enterprise-diagram-300x200.gif 300w" sizes="(max-width: 540px) 100vw, 540px" /></p>
-    <p><a href="/brand//assets/colour-palette">More about the colour palette</a></p>
+    <p><a href="/brand/colour-palette">More about the colour palette</a></p>
     <h3>Keylines and graphic accents</h3>
     <h4>Chart keylines</h4>
     <p>The tightly spaced dots are used for chart keylines.</p>

--- a/brand/ubuntu-logo/index.md
+++ b/brand/ubuntu-logo/index.md
@@ -56,7 +56,7 @@ body-class: "guidelines"
     <div class="col-8">
       <h2>Wordmark — Available colourways</h2>
       <p>The logo is supplied as Pantone and CMYK versions for print, and HEX versions for web. It can only be used on one of the Ubuntu colours.</p>
-      <p>Never change any of the colours in the logo. For detailed colour specifications refer to the <a title="Colour palette" href="/assets/colour-palette">colours section</a>.</p>
+      <p>Never change any of the colours in the logo. For detailed colour specifications refer to the <a title="Colour palette" href="/brand/colour-palette">colours section</a>.</p>
       <p><img title="Wordmark colourways" src="{{ site.assets_path }}8aff3fa9-ubuntu-logo41.png" alt="Wordmark colourways" width="540" height="208" srcset="{{ site.assets_path }}8aff3fa9-ubuntu-logo41.png 540w, {{ site.assets_path }}af48e40d-ubuntu-logo41-300x115.png 300w"
           sizes="(max-width: 540px) 100vw, 540px" /></p>
     </div>
@@ -68,7 +68,7 @@ body-class: "guidelines"
     <div class="col-8">
       <h2>Circle of Friends — Available colourways</h2>
       <p>The Circle of Friends is also supplied as Pantone and CMYK versions for print, and HEX versions for web. It can only be used on one of the Ubuntu colours.</p>
-      <p>Never change any of the colours in the logo. For detailed colour specifications refer to the <a title="Colour palette" href="/assets/colour-palette">colours section</a>.</p>
+      <p>Never change any of the colours in the logo. For detailed colour specifications refer to the <a title="Colour palette" href="/brand/colour-palette">colours section</a>.</p>
       <p><img title="Circle of Friends colourways" src="{{ site.assets_path }}d41eabfc-ubuntu-logo51.png" alt="Circle of Friends colourways" width="540" height="143" srcset="{{ site.assets_path }}d41eabfc-ubuntu-logo51.png 540w, {{ site.assets_path }}fcd7501c-ubuntu-logo51-300x79.png 300w"
           sizes="(max-width: 540px) 100vw, 540px" /></p>
     </div>


### PR DESCRIPTION
## Done

Fix link to colour palette 

## QA

- Go to <http://0.0.0.0:8011/brand/ubuntu-logo/> and see that the `colours section` link doesn't lead to a 404
- Go to <http://0.0.0.0:8011/brand/illustration/> and see that the `More about the colour palette` link doesn't lead to a 404

## Issue / Card

Fixes #112