### PR TITLE
Fix colour palette link

### DIFF
--- a/brand/ubuntu-logo/index.md
+++ b/brand/ubuntu-logo/index.md
@@ -68,7 +68,7 @@ body-class: "guidelines"
     <div class="col-8">
       <h2>Circle of Friends — Available colourways</h2>
       <p>The Circle of Friends is also supplied as Pantone and CMYK versions for print, and HEX versions for web. It can only be used on one of the Ubuntu colours.</p>
-      <p>Never change any of the colours in the logo. For detailed colour specifications refer to the <a title="Colour palette" href="/assets/colour-palette">colours section</a>.</p>
+      <p>Never change any of the colours in the logo. For detailed colour specifications refer to the <a title="Colour palette" href="/brand/colour-palette">colours section</a>.</p>
       <p><img title="Circle of Friends colourways" src="{{ site.assets_path }}d41eabfc-ubuntu-logo51.png" alt="Circle of Friends colourways" width="540" height="143" srcset="{{ site.assets_path }}d41eabfc-ubuntu-logo51.png 540w, {{ site.assets_path }}fcd7501c-ubuntu-logo51-300x79.png 300w"
           sizes="(max-width: 540px) 100vw, 540px" /></p>
     </div>


### PR DESCRIPTION
## Done

- Fixed a link that 404'd. 

## QA

- Go to https://design.ubuntu.com/brand/ubuntu-logo/ , go to the "Circle of Friends — Available colourways" and click the link. It should go to  https://design.ubuntu.com/brand/colour-palette/ and not 404. 

## Issue / Card

Fixes: #112 

