### PR TITLE
fix link to /downloads on canonical-logo page

### DIFF
--- a/brand/canonical-logo/index.md
+++ b/brand/canonical-logo/index.md
@@ -157,7 +157,7 @@ body-class: "guidelines"
   <div class="row">
     <div class="col-8">
       <p>
-        <a href="../downloads" title="Download Canonical logos">View Canonical logos available for download&nbsp;&rsaquo;</a>
+        <a href="/downloads" title="Download Canonical logos">View Canonical logos available for download&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

on /brand/canonical-logo I updated the link to /downloads

## QA

- run the site
- see the download link on /brand/canonical-logo goes to /downloads

## Issue / Card

Fixes #122

